### PR TITLE
Commit status: move test results before "Merged build finished" message

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/ghprb/GhprbBuilds.java
+++ b/src/main/java/org/jenkinsci/plugins/ghprb/GhprbBuilds.java
@@ -125,13 +125,14 @@ public class GhprbBuilds {
             GhprbBuildManagerFactoryUtil.getBuildManager(build, jobConfiguration);
         
         StringBuilder replyMessage = new StringBuilder();
-        
-        if (c.isMerged()) {
-            replyMessage.append("Merged build finished. ");
-        } else {
-            replyMessage.append("Build finished. ");
-        }
         replyMessage.append(buildManager.getOneLineTestResults());
+
+        if (c.isMerged()) {
+            replyMessage.append(" Merged build finished.");
+        } else {
+            replyMessage.append(" Build finished.");
+        }
+
         repo.createCommitStatus(build, state, replyMessage.toString(), c.getPullID(), trigger.getCommitStatusContext(), listener.getLogger());
 
         StringBuilder msg = new StringBuilder();


### PR DESCRIPTION
With the new redesign of the GitHub commit status UI the test results got cut off,
but those are arguably more important than the "finished" message so we move them to the front.
